### PR TITLE
Move some dependencies to Suggests, use conditionally

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,19 +9,13 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
-Imports: 
+Imports:
     cli,
     dplyr,
     forcats,
-    ggbeeswarm,
     ggplot2 (>= 4.0.1),
-    ggpubr,
-    ggrastr,
-    ggrepel,
     glue,
     gtable,
-    Hmisc,
-    htmltools,
     lifecycle,
     purrr,
     rlang,
@@ -35,7 +29,13 @@ Depends:
 LazyData: true
 URL: https://github.com/jbengler/tidyplots, https://jbengler.github.io/tidyplots/
 BugReports: https://github.com/jbengler/tidyplots/issues
-Suggests: 
+Suggests:
+    ggbeeswarm,
+    ggpubr,
+    ggrastr,
+    ggrepel,
+    Hmisc,
+    htmltools,
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),

--- a/R/add-annotation.R
+++ b/R/add-annotation.R
@@ -259,6 +259,7 @@ add_data_labels_repel <- function(
   seed = 42,
   ...
 ) {
+  rlang::check_installed("ggrepel")
   plot <- check_tidyplot(plot)
   size <- fontsize / ggplot2::.pt
   background_color <- background_color %||% plot$tidyplot$paper

--- a/R/add-misc.R
+++ b/R/add-misc.R
@@ -374,6 +374,7 @@ add_geom <- function(
   level = 0
 ) {
   if (rasterize) {
+    rlang::check_installed("ggrastr")
     plot + ggrastr::rasterise(geom, dpi = rasterize_dpi, dev = "ragg")
   } else {
     plot + geom

--- a/R/add-points.R
+++ b/R/add-points.R
@@ -127,6 +127,7 @@ add_data_points_beeswarm <- function(
   rasterize_dpi = 300,
   ...
 ) {
+  rlang::check_installed("ggbeeswarm")
   plot <- check_tidyplot(plot)
   f_points(
     beeswarm = TRUE,

--- a/R/add-stats.R
+++ b/R/add-stats.R
@@ -143,6 +143,7 @@ add_test_pvalue <- function(
   hide_info = FALSE,
   ...
 ) {
+  rlang::check_installed("ggpubr")
   plot <- check_tidyplot(plot)
 
   # method.args are not supplied in ellipses

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -254,6 +254,7 @@ mean_sd <- function(x) {
 }
 
 mean_cl_boot <- function(x) {
+  rlang::check_installed("Hmisc")
   dplyr::rename(
     data.frame(as.list(Hmisc::smean.cl.boot(x))),
     y = Mean,

--- a/R/tidycolor.R
+++ b/R/tidycolor.R
@@ -714,6 +714,7 @@ generate_html <- function(x, max_colors) {
 
 print_tidycolor <- function(x, max_colors, return_html = FALSE) {
   # cli::cli_alert_info(paste0("A tidyplots color scheme with ",length(x) ," colors."))
+  rlang::check_installed("htmltools")
 
   viewer <- getOption("viewer")
   if (!is.null(viewer) || return_html) {


### PR DESCRIPTION
TL;DR: This PR enables people to use tidyplots without installing certain other packages like ggpubr, as long as people don't use the specific functions that rely on those packages.

Some of this was discussed in https://github.com/jbengler/tidyplots/pull/168#issuecomment-4237623945.

### Problem

Before this PR, `R CMD check` said in an INFO:
```
   Imports includes 21 non-default packages.
   Importing from so many packages makes the package vulnerable to any of
   them becoming unavailable.  Move as many as possible to Suggests and
   use conditionally.
```

This requires *any* user of tidyplots to install *all* of those packages as well as their dependencies, and the dependencies of those dependencies, etc.

In the worst-case scenario, any one of these packages could go defunct, and so would tidyplots. Many of them are by Posit employees, and Posit has safeguards against this – but some packages, especially ggplot2 wrappers, were written by independent developers.

Even without a landslide of CRAN removals, an abundance of dependencies could become an issue in Shiny apps, or in other packages that might, in turn, import tidyplots. Also, I imagine it could potentially inhibit the addition of new features relying on other packages because that would mean taking on these packages as dependencies. (But I don't know what you actually think about this.)

### Proposed solution

The PR implements a "best of both worlds" approach: It adds feature gates for ggbeeswarm, ggpubr, ggrastr, ggrepel, Hmisc, and htmltools. All of these have isolated use cases within tidyplots. The gates use `rlang::check_installed()`.

This enables users to install and use tidyplots without a given dependency unless they call tidyplots functions which rely on that specific dependency. In DESCRIPTION, this allows us to move the dependency from Imports to Suggests. With these changes, `R CMD check` no longer displays the INFO quoted above.

For example, `add_test_pvalue()` and `add_test_pvalue_manual()` are currently the only tidyplots functions that rely on ggpubr. If we call `rlang::check_installed("ggpubr")` inside of these functions and move ggpubr to Suggests, as this PR does, the user will not even notice the tidyplots-ggpubr connection unless they call `add_test_pvalue()` without having ggpubr installed. If they do, they will see this:

```
ℹ The package "ggpubr" is required.
✖ Would you like to install it?

1: Yes
2: No

Selection: 
```

Of course, the same approach could be used to make future dependencies optional – if such packages will only be used in a few tidyplots functions.

(I made the changes by hand, but after that, I had Claude resolve a Git issue.)

### About specific checks
The check for ggrastr only runs if the user set `rasterize` to `TRUE` in `add_data_points()`, `add_data_points_jitter()`, `add_data_points_beeswarm()`, or `add_heatmap()`.

The check for Hmisc is run within the `mean_cl_boot()` helper. It would be awkward to run it directly in an exported function because of the factory system. The exported functions that use Hmisc all rely on `mean_cl_boot()`.

### Limitations

`check_installed()` is not helpful for dependencies that are used throughout tidyplots, such as dplyr, cli, and ggplot2 itself. The same applies to indirect dependencies. For example, tidyplots imports ggplot2, which imports gtable, so tidyplots has a strong implicit dependency on gtable and can't work around it.

### Point of comparison: `purrr::in_parallel()`

Since [version 1.1.0](https://tidyverse.org/blog/2025/07/purrr-1-1-0-parallel/), purrr has supported built-in parallel processing via the new `in_parallel()` function. This relies on the carrier and mirai packages. However, purrr lists carrier and mirai [in Suggests, not in Imports](https://cran.r-project.org/web/packages/purrr/index.html).

This works because `in_parallel()` calls `check_installed()` for carrier and mirai (indirectly via a helper). So people can use most purrr functions without installing these two packages.